### PR TITLE
Reduce RE port count by one for windows compatibility

### DIFF
--- a/full-2qfx-4srv-evpnvxlan/Vagrantfile
+++ b/full-2qfx-4srv-evpnvxlan/Vagrantfile
@@ -65,7 +65,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
                 virtualbox__intnet: "#{UUID}_vqfx_interconnect"
 
             # Dataplane ports (Yes, dataplane ports are mapped on the RE and not PFE for vQFX10k)
-            (1..5).each do |seg_id|
+            (1..4).each do |seg_id|
                vqfx.vm.network 'private_network', 
                 auto_config: false, 
                 nic_type: '82540EM', 


### PR DESCRIPTION
In an effort to get this working for Windows users, this PR reduces the RE port count by one, as [Windows Virtualbox has a hard limit at 8](https://github.com/hashicorp/vagrant/issues/7417) (existing config results in 9 on the RE).

From what I can tell, this reduction is only over the `em` interfaces (the highest one is now `em7`) which aren't used for this lab, or even configured.

Everything is still converged and reachable:

```
vagrant@vqfx1> show bgp summary
Groups: 1 Peers: 1 Down peers: 0
Table          Tot Paths  Act Paths Suppressed    History Damp State    Pending
bgp.evpn.0
                      10         10          0          0          0          0
Peer                     AS      InPkt     OutPkt    OutQ   Flaps Last Up/Dwn State|#Active/Received/Accepted/Damped...
9.9.9.2               64500         43         42       0       0       14:20 Establ
  bgp.evpn.0: 10/10/10/0
  default-switch.evpn.0: 10/10/10/0
  __default_evpn__.evpn.0: 0/0/0/0

{master:0}
vagrant@vqfx1> show ospf route
Topology default Route Table:

Prefix             Path  Route      NH       Metric NextHop       Nexthop
                   Type  Type       Type            Interface     Address/LSP
9.9.9.2            Intra Router     IP            1 xe-0/0/0.0    10.0.0.2
9.9.9.1/32         Intra Network    IP            0 lo0.0
9.9.9.2/32         Intra Network    IP            1 xe-0/0/0.0    10.0.0.2
10.0.0.0/30        Intra Network    IP            1 xe-0/0/0.0

{master:0}
```

```
~$ vagrant ssh srv11
Welcome to Ubuntu 14.04.1 LTS (GNU/Linux 3.13.0-35-generic x86_64)

 * Documentation:  https://help.ubuntu.com/
Last login: Thu Sep  4 17:40:24 2014 from 10.0.2.2
vagrant@srv11:~$ ifconfig eth1
eth1      Link encap:Ethernet  HWaddr 08:00:27:d1:0e:15
          inet addr:10.10.1.10  Bcast:10.10.1.255  Mask:255.255.255.0
          inet6 addr: fe80::a00:27ff:fed1:e15/64 Scope:Link
          UP BROADCAST RUNNING MULTICAST  MTU:1500  Metric:1
          RX packets:1 errors:0 dropped:0 overruns:0 frame:0
          TX packets:8 errors:0 dropped:0 overruns:0 carrier:0
          collisions:0 txqueuelen:1000
          RX bytes:60 (60.0 B)  TX bytes:648 (648.0 B)

vagrant@srv11:~$ ping 10.10.2.10
PING 10.10.2.10 (10.10.2.10) 56(84) bytes of data.
64 bytes from 10.10.2.10: icmp_seq=4 ttl=63 time=101 ms
64 bytes from 10.10.2.10: icmp_seq=5 ttl=63 time=101 ms
64 bytes from 10.10.2.10: icmp_seq=6 ttl=63 time=101 ms
64 bytes from 10.10.2.10: icmp_seq=7 ttl=63 time=100 ms
64 bytes from 10.10.2.10: icmp_seq=8 ttl=63 time=100 ms
64 bytes from 10.10.2.10: icmp_seq=9 ttl=63 time=101 ms
64 bytes from 10.10.2.10: icmp_seq=10 ttl=63 time=100 ms
64 bytes from 10.10.2.10: icmp_seq=11 ttl=63 time=101 ms
64 bytes from 10.10.2.10: icmp_seq=12 ttl=63 time=101 ms
64 bytes from 10.10.2.10: icmp_seq=13 ttl=63 time=101 ms
64 bytes from 10.10.2.10: icmp_seq=14 ttl=63 time=101 ms
^C
--- 10.10.2.10 ping statistics ---
30 packets transmitted, 27 received, 10% packet loss, time 29077ms
rtt min/avg/max/mdev = 100.272/104.925/170.281/14.063 ms
vagrant@srv11:~$ ping 10.10.1.20
PING 10.10.1.20 (10.10.1.20) 56(84) bytes of data.
From 10.10.1.10 icmp_seq=1 Destination Host Unreachable
From 10.10.1.10 icmp_seq=2 Destination Host Unreachable
From 10.10.1.10 icmp_seq=3 Destination Host Unreachable
From 10.10.1.10 icmp_seq=4 Destination Host Unreachable
From 10.10.1.10 icmp_seq=5 Destination Host Unreachable
From 10.10.1.10 icmp_seq=6 Destination Host Unreachable
64 bytes from 10.10.1.10: icmp_seq=7 ttl=64 time=1385 ms
64 bytes from 10.10.1.10: icmp_seq=8 ttl=64 time=384 ms
64 bytes from 10.10.1.10: icmp_seq=9 ttl=64 time=103 ms
64 bytes from 10.10.1.10: icmp_seq=10 ttl=64 time=103 ms
64 bytes from 10.10.1.10: icmp_seq=11 ttl=64 time=103 ms
64 bytes from 10.10.1.10: icmp_seq=12 ttl=64 time=103 ms
 64 bytes from 10.10.1.10: icmp_seq=13 ttl=64 time=102 ms
^C
--- 10.10.1.20 ping statistics ---
13 packets transmitted, 7 received, +6 errors, 46% packet loss, time 12010ms
rtt min/avg/max/mdev = 102.030/326.527/1385.266/442.995 ms, pipe 3
vagrant@srv11:~$ ping 10.10.2.20
PING 10.10.2.20 (10.10.2.20) 56(84) bytes of data.
64 bytes from 10.10.2.20: icmp_seq=8 ttl=63 time=303 ms
64 bytes from 10.10.2.20: icmp_seq=9 ttl=63 time=103 ms
64 bytes from 10.10.2.20: icmp_seq=10 ttl=63 time=121 ms
^C
--- 10.10.2.20 ping statistics ---
10 packets transmitted, 3 received, 70% packet loss, time 9059ms
rtt min/avg/max/mdev = 103.316/176.114/303.144/90.142 ms
```

I'll follow up with another PR to remove the Windows conditional for Ansible provisioning to round out Windows support.

Closes https://github.com/Juniper/vqfx10k-vagrant/issues/17