### PR TITLE
Do not use "ingress-node-replication" with VXLAN

### DIFF
--- a/full-2qfx-4srv-evpnvxlan/vqfx.conf.j2
+++ b/full-2qfx-4srv-evpnvxlan/vqfx.conf.j2
@@ -150,7 +150,6 @@ vlans {
         l3-interface irb.{{ vlan.vxlan_id }};
         vxlan {
             vni {{ vlan.vxlan_id }};
-            ingress-node-replication;
         }
     }
 {% endfor %}


### PR DESCRIPTION
JTAC advises to not use "ingress-node-replication" when using BGP EVPN VXLAN. "multicast-mode ingress-replication" is enough to achieve the same effect. "ingress-node-replication" will replicate packets to VTEP not advertising the Type 3 route and also incurs a low-level overhead which may exhaust the chipset capacity (on a Broadcom platform for example). Please check with a QFX engineer if needed.