### PR TITLE
Direct COM1 to file to improve boot time.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ build/
 # Ignore vagrant dir and all generated Conf file
 .vagrant/
 *.conf
+
+# Ignore log files
+*.log

--- a/full-1qfx-1srv/Vagrantfile
+++ b/full-1qfx-1srv/Vagrantfile
@@ -6,6 +6,7 @@ VAGRANTFILE_API_VERSION = "2"
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
     re_name  = "vqfx"
+    re_log   = "vqfx.log"
     pfe_name = "vqfx-pfe"
 
     ##############################
@@ -27,6 +28,11 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
         vqfx.vm.hostname = "vqfx"
         vqfx.vm.box = 'juniper/vqfx10k-re'
         vqfx.ssh.insert_key = false
+
+        # VM can be really slow unless COM1 is connected to something.
+        vqfx.vm.provider "virtualbox" do |v|
+            v.customize ["modifyvm", :id, "--uartmode1", "file", re_log]
+        end
 
         # DO NOT REMOVE / NO VMtools installed
         vqfx.vm.synced_folder '.', '/vagrant', disabled: true

--- a/full-1qfx-1srv/Vagrantfile
+++ b/full-1qfx-1srv/Vagrantfile
@@ -6,7 +6,6 @@ VAGRANTFILE_API_VERSION = "2"
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
     re_name  = "vqfx"
-    re_log   = "vqfx.log"
     pfe_name = "vqfx-pfe"
 
     ##############################
@@ -30,6 +29,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
         vqfx.ssh.insert_key = false
 
         # VM can be really slow unless COM1 is connected to something.
+        Vagrant::Util::Platform.windows? ? ( re_log = "NUL" ) : ( re_log = "/dev/null" )
         vqfx.vm.provider "virtualbox" do |v|
             v.customize ["modifyvm", :id, "--uartmode1", "file", re_log]
         end

--- a/full-1qfx/Vagrantfile
+++ b/full-1qfx/Vagrantfile
@@ -9,7 +9,6 @@ UUID = [*('A'..'Z')].sample(6).join
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
     re_name  = "vqfx"
-    re_log   = "vqfx.log"
     pfe_name = "vqfx-pfe"
 
     ##############################
@@ -33,6 +32,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
         vqfx.vm.box = 'juniper/vqfx10k-re'
 
         # VM can be really slow unless COM1 is connected to something.
+        Vagrant::Util::Platform.windows? ? ( re_log = "NUL" ) : ( re_log = "/dev/null" )
         vqfx.vm.provider "virtualbox" do |v|
             v.customize ["modifyvm", :id, "--uartmode1", "file", re_log]
         end

--- a/full-1qfx/Vagrantfile
+++ b/full-1qfx/Vagrantfile
@@ -9,6 +9,7 @@ UUID = [*('A'..'Z')].sample(6).join
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
     re_name  = "vqfx"
+    re_log   = "vqfx.log"
     pfe_name = "vqfx-pfe"
 
     ##############################
@@ -30,6 +31,11 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
         vqfx.ssh.insert_key = false
         vqfx.vm.hostname = "vqfx"
         vqfx.vm.box = 'juniper/vqfx10k-re'
+
+        # VM can be really slow unless COM1 is connected to something.
+        vqfx.vm.provider "virtualbox" do |v|
+            v.customize ["modifyvm", :id, "--uartmode1", "file", re_log]
+        end
 
         # DO NOT REMOVE / NO VMtools installed
         vqfx.vm.synced_folder '.', '/vagrant', disabled: true

--- a/full-2qfx-4srv-evpnvxlan/Vagrantfile
+++ b/full-2qfx-4srv-evpnvxlan/Vagrantfile
@@ -11,6 +11,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
     (1..2).each do |id|
         re_name  = ( "vqfx" + id.to_s ).to_sym
+        re_log   = ( "vqfx" + id.to_s + ".log" )
         pfe_name = ( "vqfx" + id.to_s + "-pfe" ).to_sym
         
         ##############################
@@ -44,6 +45,11 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
             vqfx.vm.hostname = "vqfx#{id}"
             vqfx.vm.box = 'juniper/vqfx10k-re'
             vqfx.vm.boot_timeout = 600
+
+            # VM can be really slow unless COM1 is connected to something.
+            vqfx.vm.provider "virtualbox" do |v|
+                v.customize ["modifyvm", :id, "--uartmode1", "file", re_log]
+            end
 
             # DO NOT REMOVE / NO VMtools installed
             vqfx.vm.synced_folder '.', 

--- a/full-2qfx-4srv-evpnvxlan/Vagrantfile
+++ b/full-2qfx-4srv-evpnvxlan/Vagrantfile
@@ -11,7 +11,6 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
     (1..2).each do |id|
         re_name  = ( "vqfx" + id.to_s ).to_sym
-        re_log   = ( "vqfx" + id.to_s + ".log" )
         pfe_name = ( "vqfx" + id.to_s + "-pfe" ).to_sym
         
         ##############################
@@ -47,6 +46,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
             vqfx.vm.boot_timeout = 600
 
             # VM can be really slow unless COM1 is connected to something.
+            Vagrant::Util::Platform.windows? ? ( re_log = "NUL" ) : ( re_log = "/dev/null" )
             vqfx.vm.provider "virtualbox" do |v|
                 v.customize ["modifyvm", :id, "--uartmode1", "file", re_log]
             end

--- a/full-2qfx/Vagrantfile
+++ b/full-2qfx/Vagrantfile
@@ -11,6 +11,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
     (1..2).each do |id|
         re_name  = ( "vqfx" + id.to_s ).to_sym
+        re_log   = ( "vqfx" + id.to_s + ".log" )
         pfe_name = ( "vqfx" + id.to_s + "-pfe" ).to_sym
 
         ##############################
@@ -36,6 +37,11 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
         config.vm.define re_name do |vqfx|
             vqfx.vm.hostname = "vqfx#{id}"
             vqfx.vm.box = 'juniper/vqfx10k-re'
+
+            # VM can be really slow unless COM1 is connected to something.
+            vqfx.vm.provider "virtualbox" do |v|
+                v.customize ["modifyvm", :id, "--uartmode1", "file", re_log]
+            end
 
             # DO NOT REMOVE / NO VMtools installed
             vqfx.vm.synced_folder '.', '/vagrant', disabled: true

--- a/full-2qfx/Vagrantfile
+++ b/full-2qfx/Vagrantfile
@@ -11,7 +11,6 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
     (1..2).each do |id|
         re_name  = ( "vqfx" + id.to_s ).to_sym
-        re_log   = ( "vqfx" + id.to_s + ".log" )
         pfe_name = ( "vqfx" + id.to_s + "-pfe" ).to_sym
 
         ##############################
@@ -39,6 +38,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
             vqfx.vm.box = 'juniper/vqfx10k-re'
 
             # VM can be really slow unless COM1 is connected to something.
+            Vagrant::Util::Platform.windows? ? ( re_log = "NUL" ) : ( re_log = "/dev/null" )
             vqfx.vm.provider "virtualbox" do |v|
                 v.customize ["modifyvm", :id, "--uartmode1", "file", re_log]
             end

--- a/full-4qfx/Vagrantfile
+++ b/full-4qfx/Vagrantfile
@@ -18,7 +18,6 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
     (1..4).each do |id|
         re_name  = ( "vqfx" + id.to_s ).to_sym
-        re_log   = ( "vqfx" + id.to_s + ".log" )
         pfe_name = ( "vqfx" + id.to_s + "-pfe" ).to_sym
 
         # ##############################
@@ -46,6 +45,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
             vqfx.vm.box = 'juniper/vqfx10k-re'
 
             # VM can be really slow unless COM1 is connected to something.
+            Vagrant::Util::Platform.windows? ? ( re_log = "NUL" ) : ( re_log = "/dev/null" )
             vqfx.vm.provider "virtualbox" do |v|
                 v.customize ["modifyvm", :id, "--uartmode1", "file", re_log]
             end

--- a/full-4qfx/Vagrantfile
+++ b/full-4qfx/Vagrantfile
@@ -18,6 +18,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
     (1..4).each do |id|
         re_name  = ( "vqfx" + id.to_s ).to_sym
+        re_log   = ( "vqfx" + id.to_s + ".log" )
         pfe_name = ( "vqfx" + id.to_s + "-pfe" ).to_sym
 
         # ##############################
@@ -43,6 +44,11 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
         config.vm.define re_name do |vqfx|
             vqfx.vm.hostname = "vqfx#{id}"
             vqfx.vm.box = 'juniper/vqfx10k-re'
+
+            # VM can be really slow unless COM1 is connected to something.
+            vqfx.vm.provider "virtualbox" do |v|
+                v.customize ["modifyvm", :id, "--uartmode1", "file", re_log]
+            end
 
             # DO NOT REMOVE / NO VMtools installed
             vqfx.vm.synced_folder '.', '/vagrant', disabled: true

--- a/full-ipfabric-2S-3L/Vagrantfile
+++ b/full-ipfabric-2S-3L/Vagrantfile
@@ -24,6 +24,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     ##########################
     (1..2).each do |id|
         re_name  = ( "spine" + id.to_s ).to_sym
+        re_log   = ( "spine" + id.to_s + ".log" )
         pfe_name = ( "spine" + id.to_s + "-pfe" ).to_sym
 
         ##############################
@@ -58,6 +59,11 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
             vqfx.vm.box = 'juniper/vqfx10k-re'
             vqfx.vm.boot_timeout = 600
 
+            # VM can be really slow unless COM1 is connected to something.
+            vqfx.vm.provider "virtualbox" do |v|
+                v.customize ["modifyvm", :id, "--uartmode1", "file", re_log]
+            end
+
             # DO NOT REMOVE / NO VMtools installed
             vqfx.vm.synced_folder '.', '/vagrant', disabled: true
 
@@ -88,6 +94,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     ##########################
     (1..3).each do |id|
         re_name  = ( "leaf" + id.to_s ).to_sym
+        re_log   = ( "leaf" + id.to_s + ".log" )
         pfe_name = ( "leaf" + id.to_s + "-pfe" ).to_sym
         srv_name = ( "srv" + id.to_s ).to_sym
 
@@ -122,6 +129,11 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
             vqfx.vm.hostname = "leaf#{id}"
             vqfx.vm.box = 'juniper/vqfx10k-re'
             vqfx.vm.boot_timeout = 600
+
+            # VM can be really slow unless COM1 is connected to something.
+            vqfx.vm.provider "virtualbox" do |v|
+                v.customize ["modifyvm", :id, "--uartmode1", "file", re_log]
+            end
 
             # DO NOT REMOVE / NO VMtools installed
             vqfx.vm.synced_folder '.', '/vagrant', disabled: true

--- a/full-ipfabric-2S-3L/Vagrantfile
+++ b/full-ipfabric-2S-3L/Vagrantfile
@@ -19,12 +19,14 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
     config.ssh.insert_key = false
 
+    # Path used for routing engine console log.
+    Vagrant::Util::Platform.windows? ? ( re_log = "NUL" ) : ( re_log = "/dev/null" )
+
     ##########################
     ## Spine           #######
     ##########################
     (1..2).each do |id|
         re_name  = ( "spine" + id.to_s ).to_sym
-        re_log   = ( "spine" + id.to_s + ".log" )
         pfe_name = ( "spine" + id.to_s + "-pfe" ).to_sym
 
         ##############################
@@ -94,7 +96,6 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     ##########################
     (1..3).each do |id|
         re_name  = ( "leaf" + id.to_s ).to_sym
-        re_log   = ( "leaf" + id.to_s + ".log" )
         pfe_name = ( "leaf" + id.to_s + "-pfe" ).to_sym
         srv_name = ( "srv" + id.to_s ).to_sym
 

--- a/light-1qfx/Vagrantfile
+++ b/light-1qfx/Vagrantfile
@@ -13,6 +13,11 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
         vqfx.vm.hostname = "vqfx"
         vqfx.vm.box = 'juniper/vqfx10k-re'
 
+        # VM can be really slow unless COM1 is connected to something.
+        vqfx.vm.provider "virtualbox" do |v|
+            v.customize ["modifyvm", :id, "--uartmode1", "file", "vqfx.log"]
+        end
+
         # DO NOT REMOVE / NO VMtools installed
         vqfx.vm.synced_folder '.', '/vagrant', disabled: true
 

--- a/light-1qfx/Vagrantfile
+++ b/light-1qfx/Vagrantfile
@@ -14,8 +14,9 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
         vqfx.vm.box = 'juniper/vqfx10k-re'
 
         # VM can be really slow unless COM1 is connected to something.
+        Vagrant::Util::Platform.windows? ? ( re_log = "NUL" ) : ( re_log = "/dev/null" )
         vqfx.vm.provider "virtualbox" do |v|
-            v.customize ["modifyvm", :id, "--uartmode1", "file", "vqfx.log"]
+            v.customize ["modifyvm", :id, "--uartmode1", "file", re_log]
         end
 
         # DO NOT REMOVE / NO VMtools installed

--- a/light-2qfx-2srv/Vagrantfile
+++ b/light-2qfx-2srv/Vagrantfile
@@ -8,6 +8,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
     (1..2).each do |id|
         re_name  = ( "vqfx" + id.to_s ).to_sym
+        re_log   = ( "vqfx" + id.to_s + ".log" )
         srv_name  = ( "srv" + id.to_s ).to_sym
 
         ##########################
@@ -16,6 +17,12 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
         config.vm.define re_name do |vqfx|
             vqfx.vm.hostname = "vqfx#{id}"
             vqfx.vm.box = 'juniper/vqfx10k-re'
+
+            # VM can be really slow unless COM1 is connected to something.
+            vqfx.vm.provider "virtualbox" do |v|
+                v.customize ["modifyvm", :id, "--uartmode1", "file", re_log]
+            end
+
             # DO NOT REMOVE / NO VMtools installed
             vqfx.vm.synced_folder '.', '/vagrant', disabled: true
 

--- a/light-2qfx-2srv/Vagrantfile
+++ b/light-2qfx-2srv/Vagrantfile
@@ -8,7 +8,6 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
     (1..2).each do |id|
         re_name  = ( "vqfx" + id.to_s ).to_sym
-        re_log   = ( "vqfx" + id.to_s + ".log" )
         srv_name  = ( "srv" + id.to_s ).to_sym
 
         ##########################
@@ -19,6 +18,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
             vqfx.vm.box = 'juniper/vqfx10k-re'
 
             # VM can be really slow unless COM1 is connected to something.
+            Vagrant::Util::Platform.windows? ? ( re_log = "NUL" ) : ( re_log = "/dev/null" )
             vqfx.vm.provider "virtualbox" do |v|
                 v.customize ["modifyvm", :id, "--uartmode1", "file", re_log]
             end

--- a/light-2qfx/Vagrantfile
+++ b/light-2qfx/Vagrantfile
@@ -12,7 +12,6 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
     (1..2).each do |id|
         re_name  = ( "vqfx" + id.to_s ).to_sym
-        re_log   = ( "vqfx" + id.to_s + ".log" )
 
         ##########################
         ## Routing Engine  #######
@@ -22,6 +21,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
             vqfx.vm.box = 'juniper/vqfx10k-re'
 
             # VM can be really slow unless COM1 is connected to something.
+            Vagrant::Util::Platform.windows? ? ( re_log = "NUL" ) : ( re_log = "/dev/null" )
             vqfx.vm.provider "virtualbox" do |v|
                 v.customize ["modifyvm", :id, "--uartmode1", "file", re_log]
             end

--- a/light-2qfx/Vagrantfile
+++ b/light-2qfx/Vagrantfile
@@ -12,6 +12,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
     (1..2).each do |id|
         re_name  = ( "vqfx" + id.to_s ).to_sym
+        re_log   = ( "vqfx" + id.to_s + ".log" )
 
         ##########################
         ## Routing Engine  #######
@@ -19,6 +20,11 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
         config.vm.define re_name do |vqfx|
             vqfx.vm.hostname = "vqfx#{id}"
             vqfx.vm.box = 'juniper/vqfx10k-re'
+
+            # VM can be really slow unless COM1 is connected to something.
+            vqfx.vm.provider "virtualbox" do |v|
+                v.customize ["modifyvm", :id, "--uartmode1", "file", re_log]
+            end
 
             # DO NOT REMOVE / NO VMtools installed
             vqfx.vm.synced_folder '.', '/vagrant', disabled: true

--- a/light-ipfabric-2S-3L/Vagrantfile
+++ b/light-ipfabric-2S-3L/Vagrantfile
@@ -24,11 +24,17 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     ##########################
     (1..2).each do |id|
         re_name  = ( "spine" + id.to_s ).to_sym
+        re_log   = ( "spine" + id.to_s + ".log" )
 
         config.vm.define re_name do |vqfx|
             vqfx.vm.hostname = "spine#{id}"
             vqfx.vm.box = 'juniper/vqfx10k-re'
             vqfx.vm.boot_timeout = 600
+
+            # VM can be really slow unless COM1 is connected to something.
+            vqfx.vm.provider "virtualbox" do |v|
+                v.customize ["modifyvm", :id, "--uartmode1", "file", re_log]
+            end
 
             # DO NOT REMOVE / NO VMtools installed
             vqfx.vm.synced_folder '.', '/vagrant', disabled: true
@@ -54,12 +60,18 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     ##########################
     (1..3).each do |id|
         re_name  = ( "leaf" + id.to_s ).to_sym
+        re_log   = ( "leaf" + id.to_s + ".log" )
         srv_name = ( "srv" + id.to_s ).to_sym
 
         config.vm.define re_name do |vqfx|
             vqfx.vm.hostname = "leaf#{id}"
             vqfx.vm.box = 'juniper/vqfx10k-re'
             vqfx.vm.boot_timeout = 600
+
+            # VM can be really slow unless COM1 is connected to something.
+            vqfx.vm.provider "virtualbox" do |v|
+                v.customize ["modifyvm", :id, "--uartmode1", "file", re_log]
+            end
 
             # DO NOT REMOVE / NO VMtools installed
             vqfx.vm.synced_folder '.', '/vagrant', disabled: true

--- a/light-ipfabric-2S-3L/Vagrantfile
+++ b/light-ipfabric-2S-3L/Vagrantfile
@@ -19,6 +19,9 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
     config.ssh.insert_key = false
 
+    # Path used for routing engine console log.
+    Vagrant::Util::Platform.windows? ? ( re_log = "NUL" ) : ( re_log = "/dev/null" )
+
     ##########################
     ## Spine           #######
     ##########################
@@ -60,7 +63,6 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     ##########################
     (1..3).each do |id|
         re_name  = ( "leaf" + id.to_s ).to_sym
-        re_log   = ( "leaf" + id.to_s + ".log" )
         srv_name = ( "srv" + id.to_s ).to_sym
 
         config.vm.define re_name do |vqfx|


### PR DESCRIPTION
# Improve Boot Time on VirtualBox 6 (maybe others too?)

Boot time in VirtualBox 6 was taking 30m or so for the routing engine.
Found that the problem was related to COM1 not being connected to anything.
Connected it to a file, and now the light qfx boots in about a minute on my machine.
Made the change in all Vagrantfiles and tested to make sure it comes up.

This change only helps, hopefully a quick one to approve.